### PR TITLE
Removing body-parser dependency

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -1,5 +1,4 @@
 const express = require('express');
-const bodyParser = require('body-parser');
 const cors = require('cors');
 const mongoose = require('mongoose');
 
@@ -9,7 +8,7 @@ const app = express();
 const port = process.env.PORT || 5000;
 
 app.use(cors());
-app.use(bodyParser.json());
+app.use(express.json());
 
 const uri = process.env.ATLAS_URI;
 mongoose.connect(uri, { useNewUrlParser: true, useCreateIndex: true }


### PR DESCRIPTION
Since express 4, body-parser is deprecated so now you can use
```node
app.use(express.json());
```
in the middleware section